### PR TITLE
Add setDomainSuffixMatch to WifiEnterpriseConfig for APi >=29

### DIFF
--- a/src/main/java/org/packetfence/agent/MainActivity.java
+++ b/src/main/java/org/packetfence/agent/MainActivity.java
@@ -68,6 +68,7 @@ public class MainActivity extends Activity {
     private String password = "";
     private String caIssuer;
     private String caCrtName;
+    private String serverCN;
     private byte[] caCrt;
     private String ssid;
     private String tlsUsername;
@@ -494,6 +495,14 @@ public class MainActivity extends Activity {
                         MainActivity.this.userP12Name = (String) config.get("PayloadDisplayName");
                         MainActivity.this.tlsUsername = (String) config.get("PayloadCertificateFileName");
                     }
+                    if (payloadType.equals("com.apple.security.pkcs1")) {
+                        showInDebug("Found the EAP-TLS root certificate");
+                        MainActivity.this.serverCN = (String) config.get("PayloadCertificateFileName");
+                    } else {
+                        if (MainActivity.this.api_version >= 29) {
+                            showInBox("Your PacketFence server needs a patch or change manually the html/captive-portal/templates/wireless-profile-tls.xml and allow access to 'com.apple.security.pkcs1'");
+                        }
+                    }
                 }
                 configureWirelessConnectionWPA2TLS();
 
@@ -644,6 +653,8 @@ public class MainActivity extends Activity {
 
         mEnterpriseConfig.setPhase2Method(WifiEnterpriseConfig.Phase2.NONE);
         mEnterpriseConfig.setEapMethod(WifiEnterpriseConfig.Eap.TLS);
+        mEnterpriseConfig.setDomainSuffixMatch(MainActivity.this.serverCN);
+
         final WifiNetworkSuggestion suggestion = new WifiNetworkSuggestion.Builder()
                 .setSsid(MainActivity.this.ssid)
                 .setWpa2EnterpriseConfig(mEnterpriseConfig)
@@ -824,6 +835,7 @@ public class MainActivity extends Activity {
         mEnterpriseConfig.setPassword(MainActivity.this.password);
         mEnterpriseConfig.setPhase2Method(WifiEnterpriseConfig.Phase2.MSCHAPV2);
         mEnterpriseConfig.setEapMethod(WifiEnterpriseConfig.Eap.PEAP);
+        mEnterpriseConfig.setDomainSuffixMatch(MainActivity.this.serverCN);
 
         final WifiNetworkSuggestion suggestion = new WifiNetworkSuggestion.Builder()
                 .setSsid(MainActivity.this.ssid)

--- a/src/main/java/org/packetfence/agent/MainActivity.java
+++ b/src/main/java/org/packetfence/agent/MainActivity.java
@@ -513,8 +513,8 @@ public class MainActivity extends Activity {
                 for (int i = 1; i < categoryObj.length; i++) {
                     HashMap<?, ?> config = (HashMap<?, ?>) categoryObj[i];
                     String payloadType = (String) (config.get("PayloadType"));
-                    if (payloadType.equals("com.apple.security.ca")) {
-                        showInDebug("Found root certificate");
+                    if (payloadType.equals("com.apple.security.radius.ca")) {
+                        showInDebug("Found radius root certificate");
                         String caBytes = (String) config.get("PayloadContent");
 
                         String caCrtNoHead = new String(caBytes);
@@ -903,18 +903,12 @@ public class MainActivity extends Activity {
             showInBox("Error CC4:" + e.getMessage());
         }
 
-        showInDebug("\nMainActivity.this.serverCN\n");
-        showInDebug(MainActivity.this.caCertificate.toString());
-        showInDebug("\nMainActivity.this.serverCN\n");
-
         WifiEnterpriseConfig mEnterpriseConfig = new WifiEnterpriseConfig();
-
         mEnterpriseConfig.setIdentity(MainActivity.this.tlsUsername);
         mEnterpriseConfig.setAnonymousIdentity(MainActivity.this.tlsUsername);
         mEnterpriseConfig.setPassword(MainActivity.this.password);
         mEnterpriseConfig.setPhase2Method(WifiEnterpriseConfig.Phase2.MSCHAPV2);
         mEnterpriseConfig.setEapMethod(WifiEnterpriseConfig.Eap.PEAP);
-        mEnterpriseConfig.setDomainSuffixMatch(MainActivity.this.serverCN);
         mEnterpriseConfig.setDomainSuffixMatch(MainActivity.this.serverCN);
         mEnterpriseConfig.setCaCertificate(MainActivity.this.caCertificate);
 


### PR DESCRIPTION
Fix setWpa2EnterpriseConfig for android api >= 29

https://developer.android.com/reference/kotlin/android/net/wifi/WifiNetworkSuggestion.Builder#setWpa2EnterpriseConfig(android.net.wifi.WifiEnterpriseConfig)

https://cs.android.com/android/platform/superproject/+/master:frameworks/base/wifi/java/android/net/wifi/WifiEnterpriseConfig.java;l=1426;drc=master